### PR TITLE
EpiCurl::cleanupResponses method added

### DIFF
--- a/EpiCurl.php
+++ b/EpiCurl.php
@@ -89,6 +89,11 @@ class EpiCurl
     }
     return false;
   }
+  
+  public function cleanupResponses()
+  {
+    $this->responses = array();
+  }
 
   private function getKey($ch)
   {


### PR DESCRIPTION
EpiCurl::cleanupResponses is useful when you are no longer need responses data (i.e. in long running tasks with a lot of requests, to reduce memory usage).
