### PR TITLE
Check for completion of data before returning response

### DIFF
--- a/EpiCurl.php
+++ b/EpiCurl.php
@@ -58,7 +58,7 @@ class EpiCurl
   {
     if($key != null)
     {
-      if(isset($this->responses[$key]))
+      if(isset($this->responses[$key]['data']))
       {
         return $this->responses[$key];
       }


### PR DESCRIPTION
Hi,

We were experiencing an issue with EpiCurl where it would give an error when accessing the data after setting up a download.  We found that the code downloads the HTTP headers prior to the data itself, and meant that when we accessed the data response, it could give an error stating it was not set because it hadn't finished downloading yet.  Changing getResult to check for the 'data' key instead of the simple presence of the response guarantees that the download completes.

Let me know if I'm using this library incorrectly but this change did fix a number of issues on our end.

Thanks!
