### PR TITLE
Update EpiCurl.php for -1 Response

### DIFF
--- a/EpiCurl.php
+++ b/EpiCurl.php
@@ -79,7 +79,7 @@ class EpiCurl
         usleep($outerSleepInt);
         $outerSleepInt *= $this->sleepIncrement;
         $ms=curl_multi_select($this->mc);
-        if($ms >= 0)
+        if($ms >= CURLM_CALL_MULTI_PERFORM)
         {
           do{
             $this->execStatus = curl_multi_exec($this->mc, $this->running);


### PR DESCRIPTION
Had a situation where CURL was returning a -1.  This results in an infinite loop in this function.  

In research found this http://curl.haxx.se/libcurl/c/libcurl-errors.html where it says: 
"This is not really an error. It means you should call curl_multi_perform again without doing select() or similar in between. Before version 7.20.0 this could be returned by curl_multi_perform, but in later versions this return code is never used."

By changing to use the return code constant instead of 0 the function worked perfectly as expected.